### PR TITLE
Updated SIC Noticias URL (old one wasn't working)

### DIFF
--- a/tv.sh
+++ b/tv.sh
@@ -28,7 +28,7 @@ STREAMS=(
   "https://sic.live.impresa.pt/sic.m3u8"
   "__tvi"
   "__rtp rtp3"
-  "https://sicnot.live.impresa.pt/sicnot.m3u8"
+  "https://sicnot.live.impresa.pt/sicnot540p.m3u8"
   "__tvi24"
   "__rtp rtpmemoria"
   "__rtp rtpmadeira"


### PR DESCRIPTION
## Motivation

Old URL for SIC Notícias wasn't working (At least for me).

## Modification

Replaced with a new one found on https://sicnoticias.pt/sicnoticias/emissao-em-direto/

## Result

SIC Notícias stream is now working fine.