### PR TITLE
ARTV: streaming url changed

### DIFF
--- a/tv.sh
+++ b/tv.sh
@@ -41,7 +41,7 @@ STREAMS=(
   "__tviint"
   "https://video-auth2.iol.pt/live_tvi_ficcao/live_tvi_ficcao/edge_servers/tvificcao-720p/playlist.m3u8"
   "https://video-auth2.iol.pt/live_tvi_direct/live_tvi_direct/edge_servers/tvireality-480p/playlist.m3u8"
-  "https://playout175.livextend.cloud/livenlin4/2liveartvpub/playlist.m3u8"
+  "https://playout175.livextend.cloud/livenlin4/2liveartvpub2/playlist.m3u8"
   "--referrer='http://sapo.pt/' https://streamer-b02.videos.sapo.pt/live/portocanal/playlist.m3u8"
   "https://rakuten-euronews-8-pt.samsung.wurl.com/manifest/playlist.m3u8"
   "https://d2ve4fchffi4n1.cloudfront.net/out/v1/df356edd16f3434ab417f2c48cb1d516/index.m3u8"


### PR DESCRIPTION
Our current ARTV url is no longer working, this change points to the new URL.

Closes: #71